### PR TITLE
Allow a nil data source.

### DIFF
--- a/JNWCollectionView/JNWCollectionView.m
+++ b/JNWCollectionView/JNWCollectionView.m
@@ -137,9 +137,9 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 	_collectionViewFlags.dataSourceNumberOfSections = [dataSource respondsToSelector:@selector(numberOfSectionsInCollectionView:)];
 	_collectionViewFlags.delegateDidScroll = [dataSource respondsToSelector:@selector(collectionView:didScrollToItemAtIndexPath:)];
 	_collectionViewFlags.dataSourceViewForSupplementaryView = [dataSource respondsToSelector:@selector(collectionView:viewForSupplementaryViewOfKind:inSection:)];
-	NSAssert([dataSource respondsToSelector:@selector(collectionView:numberOfItemsInSection:)],
+	NSAssert(dataSource == nil || [dataSource respondsToSelector:@selector(collectionView:numberOfItemsInSection:)],
 			 @"data source must implement collectionView:numberOfItemsInSection");
-	NSAssert([dataSource respondsToSelector:@selector(collectionView:cellForItemAtIndexPath:)],
+	NSAssert(dataSource == nil || [dataSource respondsToSelector:@selector(collectionView:cellForItemAtIndexPath:)],
 			 @"data source must implement collectionView:cellForItemAtIndexPath:");
 }
 


### PR DESCRIPTION
Otherwise you can't `nil` out the `dataSource` in `-dealloc` (which you should do, since it's `unsafe_unretained`).
