### PR TITLE
Don't implement -keyDown:

### DIFF
--- a/JNWCollectionView/JNWCollectionView.m
+++ b/JNWCollectionView/JNWCollectionView.m
@@ -932,10 +932,6 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 	}
 }
 
-- (void)keyDown:(NSEvent *)theEvent {
-	[self interpretKeyEvents:@[ theEvent ]];
-}
-
 - (void)moveUp:(id)sender {
 	NSIndexPath *toSelect = [self.collectionViewLayout indexPathForNextItemInDirection:JNWCollectionViewDirectionUp currentIndexPath:[self indexPathForSelectedItem]];
 	[self selectItemAtIndexPath:toSelect atScrollPosition:JNWCollectionViewScrollPositionNearest animated:YES];}


### PR DESCRIPTION
The `NSResponder` machinery will do this for you. And by capturing the key down here, key equivalents wouldn't work while the collection view was the first responder.
