### PR TITLE
Make it easier to create cells manually

### DIFF
--- a/JNWCollectionView/JNWCollectionView.h
+++ b/JNWCollectionView/JNWCollectionView.h
@@ -137,13 +137,7 @@ typedef NS_ENUM(NSInteger, JNWCollectionViewScrollPosition) {
 - (void)registerClass:(Class)cellClass forCellWithReuseIdentifier:(NSString *)reuseIdentifier;
 - (void)registerClass:(Class)supplementaryViewClass forSupplementaryViewOfKind:(NSString *)kind withReuseIdentifier:(NSString *)reuseIdentifier;
 
-// These methods are used to create or reuse a new view. Cells should not be created manually. Instead,
-// these methods should be called with a reuse identifier previously registered using
-// -registerClass:forCellWithReuseIdentifier: or -registerClass:forSupplementaryViewOfKind:withReuseIdentifier:.
-//
-// If a class was not previously registered, the base cell class will be used to create the view.
-// However, for supplementary views, the class must be registered, otherwise the collection view
-// will not attempt to load any supplementary views for that kind.
+// These methods are used to create or reuse a new view.
 //
 // The identifer must not be nil, otherwise an exception will be thrown.
 - (JNWCollectionViewCell *)dequeueReusableCellWithIdentifier:(NSString *)identifier;

--- a/JNWCollectionView/JNWCollectionView.m
+++ b/JNWCollectionView/JNWCollectionView.m
@@ -201,14 +201,9 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 	JNWCollectionViewCell *cell = [self dequeueItemWithIdentifier:identifier inReusePool:self.reusableCells];
 
 	// If the view doesn't exist, we go ahead and create one. If we have a class registered
-	// for this identifier, we use it, otherwise we just create an instance of JNWCollectionViewCell.
+	// for this identifier, we use it.
 	if (cell == nil) {
 		Class cellClass = self.cellClassMap[identifier];
-
-		if (cellClass == nil) {
-			cellClass = JNWCollectionViewCell.class;
-		}
-		
 		cell = [[cellClass alloc] initWithFrame:CGRectZero];
 	}
 	
@@ -226,11 +221,6 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 	
 	if (view == nil) {
 		Class viewClass = self.supplementaryViewClassMap[identifier];
-		
-		if (viewClass == nil) {
-			viewClass = JNWCollectionViewReusableView.class;
-		}
-		
 		view = [[viewClass alloc] initWithFrame:CGRectZero];
 	}
 	

--- a/JNWCollectionView/JNWCollectionViewCell+Private.h
+++ b/JNWCollectionView/JNWCollectionViewCell+Private.h
@@ -20,7 +20,6 @@
 #import "JNWCollectionView.h"
 
 @interface JNWCollectionViewCell ()
-@property (nonatomic, copy, readwrite) NSString *reuseIdentifier;
 @property (nonatomic, weak, readwrite) JNWCollectionView *collectionView;
 @property (nonatomic, strong, readwrite) NSIndexPath *indexPath;
 @end

--- a/JNWCollectionView/JNWCollectionViewCell.h
+++ b/JNWCollectionView/JNWCollectionViewCell.h
@@ -61,7 +61,7 @@
 @property (nonatomic, assign) CGFloat crossfadeDuration;
 
 // The reuse identifier.
-@property (nonatomic, copy, readonly) NSString *reuseIdentifier;
+@property (nonatomic, copy) NSString *reuseIdentifier;
 
 // The current index path.
 @property (nonatomic, strong, readonly) NSIndexPath *indexPath;


### PR DESCRIPTION
Alright, this might be a more controversial change. And I'm presenting it to start a discussion.

The problem is that the current design makes it really hard to use cells which are loaded from a nib. That _might_ be a good thing if/since all subviews should be in `contentView`. There's no non-terrible way to do that in a nib, so it could be reasonable to disallow nibs.

If that's the case, then :-1: this PR.
