### PR TITLE
Work with Auto-Layout

### DIFF
--- a/JNWCollectionView/JNWCollectionViewCell.m
+++ b/JNWCollectionView/JNWCollectionViewCell.m
@@ -86,9 +86,11 @@
 
 	
 	_contentView = [[NSView alloc] initWithFrame:self.bounds];
+	_contentView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 	_contentView.wantsLayer = YES;
 
 	_backgroundView = [[JNWCollectionViewCellBackgroundView alloc] initWithFrame:self.bounds];
+	_backgroundView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 	
 	_crossfadeDuration = 0.25;
 	
@@ -96,13 +98,6 @@
 	[self addSubview:_backgroundView positioned:NSWindowBelow relativeTo:_contentView];
 	
 	return self;
-}
-
-- (void)layout {
-	[super layout];
-	
-	self.contentView.frame = self.bounds;
-	self.backgroundView.frame = self.bounds;
 }
 
 - (void)prepareForReuse {

--- a/demo/JNWCollectionViewDemo/DemoTableCellView.m
+++ b/demo/JNWCollectionViewDemo/DemoTableCellView.m
@@ -20,7 +20,8 @@
 - (void)commonInit {
 	self.wantsLayer = YES;
 	self.layer.backgroundColor = [NSColor redColor].CGColor;
-	self.label = [[JNWLabel alloc] initWithFrame:CGRectZero];
+	self.label = [[JNWLabel alloc] initWithFrame:self.bounds];
+	self.label.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 	[self addSubview:self.label];
 	self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawOnSetNeedsDisplay;
 }
@@ -37,15 +38,6 @@
     if (self == nil) return nil;
 	[self commonInit];
     return self;
-}
-
-- (void)layout {
-	[super layout];
-	
-	CGRect labelRect = self.bounds;
-	if (!CGRectEqualToRect(labelRect, self.label.frame)) {
-		self.label.frame = labelRect;
-	}
 }
 
 - (void)setLabelText:(NSString *)labelText {

--- a/demo/JNWCollectionViewDemo/GridCell.m
+++ b/demo/JNWCollectionViewDemo/GridCell.m
@@ -21,7 +21,8 @@
 	self = [super initWithFrame:frameRect];
 	if (self == nil) return nil;
 	
-	self.label = [[JNWLabel alloc] initWithFrame:CGRectZero];
+	self.label = [[JNWLabel alloc] initWithFrame:self.bounds];
+	self.label.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 	[self addSubview:self.label];
 	
 	return self;
@@ -35,15 +36,6 @@
 - (void)setImage:(NSImage *)image {
 	_image = image;
 	self.backgroundImage = image;
-}
-
-- (void)layout {
-	[super layout];
-	
-	CGRect labelRect = self.bounds;
-	if (!CGRectEqualToRect(labelRect, self.label.frame)) {
-		self.label.frame = labelRect;
-	}
 }
 
 - (void)setSelected:(BOOL)selected {


### PR DESCRIPTION
`JNWCollectionView` doesn't work with Auto-Layout because the `-layout` override in `JNWCollectionViewCell` was dirtying layout. Auto-Layout complains loudly:

> 2013-10-16 15:58:45.485 JNWCollectionViewDemo[23550:303] Layout still needs update after calling -[DemoTableCellView layout].  DemoTableCellView or one of its superclasses may have overridden -layout without calling super. Or, something may have dirtied layout in the middle of updating it.  Both are programming errors in Cocoa Autolayout.  The former is pretty likely to arise if some pre-Cocoa Autolayout class had a method called layout, but it should be fixed.

This changes the layout to use `autoresizingMask` instead of overriding `-layout`, making the code work with or without Auto-Layout.
