### PR TITLE
Fix crash when using list layout (#68).

### DIFF
--- a/JNWCollectionView/JNWCollectionViewListLayout.m
+++ b/JNWCollectionView/JNWCollectionViewListLayout.m
@@ -50,7 +50,7 @@ NSString * const JNWCollectionViewListLayoutFooterKind = @"JNWCollectionViewList
 	self = [super init];
 	if (self == nil) return nil;
 	_numberOfRows = numberOfRows;
-	self.rowInfo = calloc(numberOfRows - 1, sizeof(JNWCollectionViewListLayoutRowInfo));
+	self.rowInfo = calloc(numberOfRows, sizeof(JNWCollectionViewListLayoutRowInfo));
 	return self;
 }
 


### PR DESCRIPTION
Fixes #68 which was caused all sorts of nasty crashes. The fix was found and suggested by @mrjjwright in the mentioned issue.
