### PR TITLE
Make it possible to clear a cell’s background.

### DIFF
--- a/JNWCollectionView/JNWCollectionViewCell.m
+++ b/JNWCollectionView/JNWCollectionViewCell.m
@@ -61,11 +61,8 @@
 }
 
 - (void)updateLayer {
-	if (self.image != nil) {
-		self.layer.contents = self.image;
-	} else if (self.color != nil) {
-		self.layer.backgroundColor = self.color.CGColor;
-	}
+	self.layer.contents = self.image;
+	self.layer.backgroundColor = self.color.CGColor;
 }
 
 @end


### PR DESCRIPTION
Before this change it was not possible to clear a cell’s background after having set either the background image or color.
