### PR TITLE
Revert addition of a scroll view background color property

### DIFF
--- a/JNWCollectionView/JNWCollectionViewFramework.h
+++ b/JNWCollectionView/JNWCollectionViewFramework.h
@@ -164,17 +164,10 @@ typedef NS_ENUM(NSInteger, JNWCollectionViewScrollPosition) {
 @property (nonatomic, strong) JNWCollectionViewLayout *collectionViewLayout;
 
 /// The background color determines what is drawn underneath any cells that might be visible
-/// at the time. This is different from NSScrollView's background color, which only sets the
-/// color underneath the document view.
+/// at the time. If this is a repeating pattern image, it will scroll along with the content.
 ///
 /// Defaults to a white color.
 @property (nonatomic, strong) NSColor *backgroundColor;
-
-/// The background color of the scroll view. This only determines the color that lies
-/// underneath the document view, and does not scroll along with the content.
-///
-/// Defaults to a clear color.
-@property (nonatomic, strong) NSColor *scrollViewBackgroundColor;
 
 /// Whether or not the collection view draws the background color. If the collection view
 /// background color needs to be transparent, this should be disabled.

--- a/JNWCollectionView/JNWCollectionViewFramework.m
+++ b/JNWCollectionView/JNWCollectionViewFramework.m
@@ -74,6 +74,7 @@ typedef NS_ENUM(NSInteger, JNWCollectionViewSelectionType) {
 
 @implementation JNWCollectionView
 @dynamic drawsBackground;
+@dynamic backgroundColor;
 
 // We're using a static function for the common initialization so that subclassers
 // don't accidentally override this method in their own common init method.
@@ -103,7 +104,6 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 	collectionView.allowsSelection = YES;
 	
 	collectionView.backgroundColor = NSColor.whiteColor;
-	collectionView.scrollViewBackgroundColor = NSColor.clearColor;
 	collectionView.drawsBackground = YES;
 }
 
@@ -293,22 +293,6 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 	if (_collectionViewFlags.wantsLayout) {
 		[self reloadData];
 	}
-}
-
-- (void)setBackgroundColor:(NSColor *)backgroundColor {
-	self.contentView.backgroundColor = backgroundColor;
-}
-
-- (NSColor *)backgroundColor {
-	return self.contentView.backgroundColor;
-}
-
-- (void)setScrollViewBackgroundColor:(NSColor *)scrollViewBackgroundColor {
-	super.backgroundColor = scrollViewBackgroundColor;
-}
-
-- (NSColor *)scrollViewBackgroundColor {
-	return super.backgroundColor;
 }
 
 #pragma mark Cell Information


### PR DESCRIPTION
Also remove the override of the original `backgroundColor` property.

After looking carefully at Apple’s documentation it turns out that scroll views and content views don’t maintain a separate state of background color, rather they share the same state. So it should Do The Right Thing™.
#84.
