### PR TITLE
Adding property to enable/disable item padding in grid layout

### DIFF
--- a/JNWCollectionView/JNWCollectionViewGridLayout.h
+++ b/JNWCollectionView/JNWCollectionViewGridLayout.h
@@ -58,6 +58,6 @@ extern NSString * const JNWCollectionViewGridLayoutFooterKind;
 /// Choose whether even padding between horizontal items is enabled.
 ///
 /// Default is YES.
-@property (nonatomic, assign) BOOL enableItemPadding;
+@property (nonatomic, assign) BOOL itemPaddingEnabled;
 
 @end

--- a/JNWCollectionView/JNWCollectionViewGridLayout.m
+++ b/JNWCollectionView/JNWCollectionViewGridLayout.m
@@ -72,7 +72,7 @@ static const CGSize JNWCollectionViewGridLayoutDefaultSize = (CGSize){ 44.f, 44.
 	self = [super initWithCollectionView:collectionView];
 	if (self == nil) return nil;
 	self.itemSize = JNWCollectionViewGridLayoutDefaultSize;
-	self.enableItemPadding = YES;
+	self.itemPaddingEnabled = YES;
 	return self;
 }
 
@@ -114,7 +114,7 @@ static const CGSize JNWCollectionViewGridLayoutDefaultSize = (CGSize){ 44.f, 44.
 	
 	self.itemPadding = 0;
 	if (numberOfColumns > 0) {
-		if(self.enableItemPadding) {
+		if (self.itemPaddingEnabled) {
 			CGFloat totalPadding = totalWidth - (numberOfColumns * itemSize.width);
 			self.itemPadding = floorf(totalPadding / (numberOfColumns + 1));
 		}


### PR DESCRIPTION
New property to enable / disable even horizontal padding between items in grid layout.
