### PR TITLE
Fix issue preventing display of supplementary views when registered from...

### DIFF
--- a/JNWCollectionView/JNWCollectionViewFramework.m
+++ b/JNWCollectionView/JNWCollectionViewFramework.m
@@ -431,7 +431,7 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 
 - (NSArray *)layoutIdentifiersForSupplementaryViewsInRect:(CGRect)rect {
 	NSMutableArray *visibleIdentifiers = [NSMutableArray array];
-	NSArray *allIdentifiers = self.supplementaryViewClassMap.allKeys;
+	NSArray *allIdentifiers = [self allSupplementaryViewIdentifiers];
 	
 	if (CGRectEqualToRect(rect, CGRectZero))
 		return visibleIdentifiers;
@@ -707,7 +707,7 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 #pragma mark Supplementary Views
 
 - (NSArray *)allSupplementaryViewIdentifiers {
-	return self.supplementaryViewClassMap.allKeys;
+	return [self.supplementaryViewClassMap.allKeys arrayByAddingObjectsFromArray:self.supplementaryViewNibMap.allKeys];
 }
 
 - (NSString *)supplementaryViewIdentifierWithKind:(NSString *)kind reuseIdentifier:(NSString *)reuseIdentifier {


### PR DESCRIPTION
... a nib

When a supplementary view is registered via -[JNWCollectionView registerNib:forSupplementaryViewOfKind:withReuseIdentifier:], the collection view would never display it.

The cause was that supplementaryViewNibMap was never including when searching for supplementary view identifiers.
