### PR TITLE
@jwilling => add support for consistent margins on items in the grid layout

### DIFF
--- a/JNWCollectionView/JNWCollectionViewGridLayout.h
+++ b/JNWCollectionView/JNWCollectionViewGridLayout.h
@@ -19,6 +19,8 @@
 
 #import "JNWCollectionViewLayout.h"
 
+@class JNWCollectionViewGridLayout;
+
 /// The supplementary view kind identifiers used for the header and the footer.
 extern NSString * const JNWCollectionViewGridLayoutHeaderKind;
 extern NSString * const JNWCollectionViewGridLayoutFooterKind;
@@ -38,6 +40,11 @@ extern NSString * const JNWCollectionViewGridLayoutFooterKind;
 /// The default height for both the header and footer is 0.
 - (CGFloat)collectionView:(JNWCollectionView *)collectionView heightForHeaderInSection:(NSInteger)index;
 - (CGFloat)collectionView:(JNWCollectionView *)collectionView heightForFooterInSection:(NSInteger)index;
+
+/// Asks the delegate for section insets for a section in the grid layout
+///
+/// The default is (0, 0, 0, 0).
+- (NSEdgeInsets)collectionView:(JNWCollectionView *)collectionView layout:(JNWCollectionViewGridLayout *)collectionViewLayout insetForSectionAtIndex:(NSInteger)section;
 
 @end
 
@@ -66,7 +73,8 @@ extern NSString * const JNWCollectionViewGridLayoutFooterKind;
 @property (nonatomic, assign) CGFloat verticalSpacing;
 
 /// Optional margins for items in the grid layout.
+///
+/// Defaults to 0
 @property (nonatomic, assign) CGFloat itemHorizontalMargin;
-
 
 @end

--- a/JNWCollectionView/JNWCollectionViewGridLayout.m
+++ b/JNWCollectionView/JNWCollectionViewGridLayout.m
@@ -108,7 +108,8 @@ static const CGSize JNWCollectionViewGridLayoutDefaultSize = (CGSize){ 44.f, 44.
 	
 	BOOL delegateHeightForHeader = [self.delegate respondsToSelector:@selector(collectionView:heightForHeaderInSection:)];
 	BOOL delegateHeightForFooter = [self.delegate respondsToSelector:@selector(collectionView:heightForFooterInSection:)];
-	
+	BOOL delegateForSectionInsets = [self.delegate respondsToSelector:@selector(collectionView:layout:insetForSectionAtIndex:)];
+
 	CGFloat totalWidth = self.collectionView.visibleSize.width - self.itemHorizontalMargin;
 	NSUInteger numberOfColumns = totalWidth / (itemSize.width + self.itemHorizontalMargin);
 	NSUInteger numberOfSections = [self.collectionView numberOfSections];
@@ -133,9 +134,10 @@ static const CGSize JNWCollectionViewGridLayoutDefaultSize = (CGSize){ 44.f, 44.
 		NSInteger numberOfItems = [self.collectionView numberOfItemsInSection:section];
 		NSInteger headerHeight = delegateHeightForHeader ? [self.delegate collectionView:self.collectionView heightForHeaderInSection:section] : 0;
 		NSInteger footerHeight = delegateHeightForFooter ? [self.delegate collectionView:self.collectionView heightForFooterInSection:section] : 0;
-		
+		NSEdgeInsets sectionInsets = delegateForSectionInsets ? [self.delegate collectionView:self.collectionView layout:self insetForSectionAtIndex:section] : NSEdgeInsetsMake(0, 0, 0, 0);
+
 		JNWCollectionViewGridLayoutSection *sectionInfo = [[JNWCollectionViewGridLayoutSection alloc] initWithNumberOfItems:numberOfItems];
-		sectionInfo.offset = totalHeight + headerHeight;
+		sectionInfo.offset = totalHeight + headerHeight + sectionInsets.top;
 		sectionInfo.height = 0;
 		sectionInfo.index = section;
 		sectionInfo.headerHeight = headerHeight;
@@ -144,7 +146,7 @@ static const CGSize JNWCollectionViewGridLayoutDefaultSize = (CGSize){ 44.f, 44.
 		for (NSInteger item = 0; item < numberOfItems; item++) {
 			CGPoint origin = CGPointZero;
 			NSInteger column = ((item - (item % numberOfColumns)) / numberOfColumns);
-			origin.x = self.itemPadding + (item % numberOfColumns) * (itemSize.width + self.itemPadding);
+			origin.x = sectionInsets.left + self.itemPadding + (item % numberOfColumns) * (itemSize.width + self.itemPadding);
 			origin.y = column * itemSize.height + column * verticalSpacing;
 			sectionInfo.itemInfo[item].origin = origin;
 		}
@@ -152,7 +154,7 @@ static const CGSize JNWCollectionViewGridLayoutDefaultSize = (CGSize){ 44.f, 44.
 		NSInteger numberOfRows = ceilf((float)numberOfItems / (float)numberOfColumns);
 		
 		sectionInfo.height = itemSize.height * numberOfRows + verticalSpacing * MAX(numberOfRows - 1, 0);
-		totalHeight += sectionInfo.height + footerHeight + headerHeight;
+		totalHeight += sectionInfo.height + footerHeight + headerHeight + sectionInsets.bottom + sectionInsets.top;
 		[self.sections addObject:sectionInfo];
 	}
 }


### PR DESCRIPTION
I've been happy with JNWCollectionView! 

So I'm building a grid view but I prefer to have a consistent margin on the items. As there's already a vertical spacing modifier I've added one for horizontal. 

I'll probably send another PR to deal with alignment of the grid view items ( left / center / right ) so I can finish up the style I'm looking for, if you have any particular direction you want for that I'm open to ideas.
