### PR TITLE
Add -keyDown: implementation.

### DIFF
--- a/JNWCollectionView/JNWCollectionViewFramework.m
+++ b/JNWCollectionView/JNWCollectionViewFramework.m
@@ -1039,6 +1039,10 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 	}
 }
 
+- (void)keyDown:(NSEvent *)theEvent {
+	[self interpretKeyEvents:@[theEvent]];
+}
+
 - (void)moveUp:(id)sender {
 	NSIndexPath *toSelect = [self.collectionViewLayout indexPathForNextItemInDirection:JNWCollectionViewDirectionUp currentIndexPath:[self indexPathForSelectedItem]];
 	[self selectItemAtIndexPath:toSelect atScrollPosition:JNWCollectionViewScrollPositionNearest animated:YES];}


### PR DESCRIPTION
Without this, the various arrow key handlers (`moveDown:`, `moveUp:`, etc.) are not invoked.
