### PR TITLE
Don't override -[NSIndexPath isEqual:]

### DIFF
--- a/JNWCollectionView/NSIndexPath+JNWAdditions.m
+++ b/JNWCollectionView/NSIndexPath+JNWAdditions.m
@@ -35,8 +35,4 @@
 	return [self indexAtPosition:1];
 }
 
-- (NSString *)debugDescription {
-	return [NSString stringWithFormat:@"<%@: %p; section = %ld; item = %ld>", self.class, self, self.jnw_section, self.jnw_item];
-}
-
 @end


### PR DESCRIPTION
Index paths are used with other Cocoa classes, and may contain more than 2 items. The default implementation of -isEqual should already handle the 2-item case correctly.
