### PR TITLE
Optional grid cell's horizon alignment, when 'itemPaddingEnabled' was disabled

### DIFF
--- a/JNWCollectionView/JNWCollectionViewGridLayout.h
+++ b/JNWCollectionView/JNWCollectionViewGridLayout.h
@@ -21,6 +21,12 @@
 
 @class JNWCollectionViewGridLayout;
 
+typedef NS_ENUM(NSUInteger, NSCellAlignment) {
+    NSCellAlignmentLeft      = 0,    // Visually left aligned
+    NSCellAlignmentRight     = 1,    // Visually right aligned
+    NSCellAlignmentCenter    = 2,    // Visually centered
+};
+
 /// The supplementary view kind identifiers used for the header and the footer.
 extern NSString * const JNWCollectionViewGridLayoutHeaderKind;
 extern NSString * const JNWCollectionViewGridLayoutFooterKind;
@@ -76,5 +82,10 @@ extern NSString * const JNWCollectionViewGridLayoutFooterKind;
 ///
 /// Defaults to 0
 @property (nonatomic, assign) CGFloat itemHorizontalMargin;
+
+/// Optional grid cell's horizon alignment, when 'itemPaddingEnabled' was disabled
+///
+/// Default to NSCellAlignmentLeft
+@property (nonatomic, assign) NSCellAlignment cellAlignment;
 
 @end

--- a/JNWCollectionView/JNWCollectionViewGridLayout.m
+++ b/JNWCollectionView/JNWCollectionViewGridLayout.m
@@ -129,6 +129,11 @@ static const CGSize JNWCollectionViewGridLayoutDefaultSize = (CGSize){ 44.f, 44.
 	}
 	self.numberOfColumns = numberOfColumns;
 	
+    CGFloat extraHorizonSpace = 0.f;
+    if (self.itemPaddingEnabled == NO) {
+        extraHorizonSpace = totalWidth - (self.numberOfColumns * (itemSize.width + self.itemPadding));
+    }
+
 	CGFloat totalHeight = 0;
 	for (NSUInteger section = 0; section < numberOfSections; section++) {
 		NSInteger numberOfItems = [self.collectionView numberOfItemsInSection:section];
@@ -147,6 +152,10 @@ static const CGSize JNWCollectionViewGridLayoutDefaultSize = (CGSize){ 44.f, 44.
 			CGPoint origin = CGPointZero;
 			NSInteger column = ((item - (item % numberOfColumns)) / numberOfColumns);
 			origin.x = sectionInsets.left + self.itemPadding + (item % numberOfColumns) * (itemSize.width + self.itemPadding);
+            if (self.itemPaddingEnabled == NO && self.cellAlignment == NSCellAlignmentCenter)
+                origin.x += (extraHorizonSpace/2);
+            else if (self.itemPaddingEnabled == NO && self.cellAlignment == NSCellAlignmentRight)
+                origin.x += extraHorizonSpace;
 			origin.y = column * itemSize.height + column * verticalSpacing;
 			sectionInfo.itemInfo[item].origin = origin;
 		}

--- a/demo/JNWCollectionViewDemo/GridDemoViewController.m
+++ b/demo/JNWCollectionViewDemo/GridDemoViewController.m
@@ -28,6 +28,10 @@ static NSString * const identifier = @"CELL";
 	JNWCollectionViewGridLayout *gridLayout = [[JNWCollectionViewGridLayout alloc] init];
 	gridLayout.delegate = self;
 	gridLayout.verticalSpacing = 10.f;
+
+    // ex) Cell Alignment
+    //gridLayout.itemPaddingEnabled = NO;
+    //gridLayout.cellAlignment = NSCellAlignmentCenter;
 	
 	self.collectionView.collectionViewLayout = gridLayout;
 	self.collectionView.dataSource = self;


### PR DESCRIPTION
When grid cell's itemPadding is disabled, cells alignment is left.
So, I want to align to center grid cells.
![2015-12-18 5 13 12](https://cloud.githubusercontent.com/assets/8433643/11892356/ae4b998a-a5aa-11e5-9cee-3ce4f8689664.png)
