### PR TITLE
Nil guards for index paths passed to primitive cell (de-)selection methods

### DIFF
--- a/JNWCollectionView/JNWCollectionViewFramework.m
+++ b/JNWCollectionView/JNWCollectionViewFramework.m
@@ -879,7 +879,8 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 }
 
 - (void)deselectItemAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated {
-	if (!self.allowsSelection ||
+	if (indexPath == nil ||
+		!self.allowsSelection ||
 		(_collectionViewFlags.delegateShouldDeselect && ![self.delegate collectionView:self shouldDeselectItemAtIndexPath:indexPath]) ||
 		(!self.allowsEmptySelection && self.indexPathsForSelectedItems.count <= 1)) {
 		return;
@@ -895,7 +896,8 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 }
 
 - (void)selectItemAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated {
-	if (!self.allowsSelection ||
+	if (indexPath == nil ||
+		!self.allowsSelection ||
 		(_collectionViewFlags.delegateShouldSelect && ![self.delegate collectionView:self shouldSelectItemAtIndexPath:indexPath])) {
 		return;
 	}


### PR DESCRIPTION
Calling `selectItemAtIndexPath:animated:` with indexPath = nil results in a NSInvalidArgumentException when it tries to add the index path to `selectedIndexes`. This currently happens when the collection view's data source returns an empty list of items and `allowsEmptySelection` is off, in which case the index path returned by `indexPathForNextSelectableItemAfterIndexPath:` is nil and then passed to `selectItemAtIndexPath:animated:` in `reloadData`.