### PR TITLE
Remove selected IndexPath before notifying delegate

### DIFF
--- a/JNWCollectionView/JNWCollectionViewFramework.m
+++ b/JNWCollectionView/JNWCollectionViewFramework.m
@@ -316,14 +316,16 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 
 - (void)reloadData {
 	_collectionViewFlags.wantsLayout = YES;
-			
-	// Remove any selected indexes we've been tracking.
+
+	// Remove and notify any selected indexes we've been tracking.
+	NSArray *selectedIndexes = self.selectedIndexes.copy;
+	[self.selectedIndexes removeAllObjects];
+
 	if (_collectionViewFlags.delegateDidDeselect) {
-		for (NSIndexPath *indexPath in self.selectedIndexes) {
+		for (NSIndexPath *indexPath in selectedIndexes) {
 			[self.delegate collectionView:self didDeselectItemAtIndexPath:indexPath];
 		}
 	}
-	[self.selectedIndexes removeAllObjects];
 	
 	[self.data recalculateAndPrepareLayout:YES];
 	[self performFullRelayoutForcingSubviewsReset:YES];


### PR DESCRIPTION
The contract for deselectItemAtIndexPath is to remove the index path
from the array before notifying the delegate. This allows the user
to check the selectedIndexes if there are remaining selections.

This patch applies this contract to reloadData where until now
selectedIndexes was cleaned after notifying the delegate.