### PR TITLE
Do not pass up mouse actions on cell for Issue #166

### DIFF
--- a/JNWCollectionView/JNWCollectionViewCell.m
+++ b/JNWCollectionView/JNWCollectionViewCell.m
@@ -158,14 +158,10 @@
 }
 
 - (void)mouseDown:(NSEvent *)theEvent {
-	[super mouseDown:theEvent];
-	
 	[self.collectionView mouseDownInCollectionViewCell:self withEvent:theEvent];
 }
 
 - (void)mouseUp:(NSEvent *)theEvent {
-	[super mouseUp:theEvent];
-	
 	[self.collectionView mouseUpInCollectionViewCell:self withEvent:theEvent];
 	
 	if (theEvent.clickCount == 2) {
@@ -174,9 +170,10 @@
 }
 
 - (void)rightMouseDown:(NSEvent *)theEvent {
-	[super rightMouseDown:theEvent];
-	
 	[self.collectionView rightClickInCollectionViewCell:self withEvent:theEvent];
+}
+
+- (void)rightMouseUp:(NSEvent *)theEvent {
 }
 
 #pragma mark NSObject


### PR DESCRIPTION
Until now the cell forwarded mouse down/up events that it handled to
the super implementation. This means that the events are forwarded to
the parent views underneath the cell.

This patch removes the super calls. The cell is handling the calls and
should not forward the actions to the view underneath.

This allows to differentiate between clicks on a cell and clicks in
non-cell space.