### PR TITLE
Preventing subview reset when reloading the layout

### DIFF
--- a/JNWCollectionView/JNWCollectionViewFramework.m
+++ b/JNWCollectionView/JNWCollectionViewFramework.m
@@ -600,7 +600,7 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 		BOOL shouldInvalidate = [self.collectionViewLayout shouldInvalidateLayoutForBoundsChange:visibleBounds];
 		[self.data recalculateAndPrepareLayout:shouldInvalidate];
 
-		[self performFullRelayoutForcingSubviewsReset:shouldInvalidate];
+		[self performFullRelayoutForcingSubviewsReset:NO];
 	}
 }
 


### PR DESCRIPTION
This fixes an issue where the `shouldInvalidate`, that is just supposed to indicate if the layout needs to be performed, was also used to determine if the previously used cells were to be reset, leading to the recreation of all cells each time a layout was done.
