### PR TITLE
Context menu fix

### DIFF
--- a/JNWCollectionView/JNWCollectionViewCell.m
+++ b/JNWCollectionView/JNWCollectionViewCell.m
@@ -187,8 +187,8 @@
 }
 
 - (void)rightMouseDown:(NSEvent *)theEvent {
-  [super rightMouseDown:theEvent];
-  
+	[super rightMouseDown:theEvent];
+
 	[self.collectionView rightClickInCollectionViewCell:self withEvent:theEvent];
 }
 

--- a/JNWCollectionView/JNWCollectionViewCell.m
+++ b/JNWCollectionView/JNWCollectionViewCell.m
@@ -187,6 +187,8 @@
 }
 
 - (void)rightMouseDown:(NSEvent *)theEvent {
+  [super rightMouseDown:theEvent];
+  
 	[self.collectionView rightClickInCollectionViewCell:self withEvent:theEvent];
 }
 


### PR DESCRIPTION
Fixed a case where the context menu wouldn't trigger, because backgroundView / contentView were used for cells and not properly calling [super rightMouseDown:]