### PR TITLE
JNWCollectionViewCell: updateTrackingAreas should call super

### DIFF
--- a/JNWCollectionView/JNWCollectionViewCell.m
+++ b/JNWCollectionView/JNWCollectionViewCell.m
@@ -119,7 +119,7 @@
 }
 
 - (void)updateTrackingAreas {
-    [super updateTrackingAreas];
+	[super updateTrackingAreas];
 	[[self.trackingAreas copy] enumerateObjectsUsingBlock:^(NSTrackingArea * _Nonnull trackingArea, NSUInteger idx, BOOL * _Nonnull stop) {
 		[self removeTrackingArea:trackingArea];
 	}];

--- a/JNWCollectionView/JNWCollectionViewCell.m
+++ b/JNWCollectionView/JNWCollectionViewCell.m
@@ -119,6 +119,7 @@
 }
 
 - (void)updateTrackingAreas {
+    [super updateTrackingAreas];
 	[[self.trackingAreas copy] enumerateObjectsUsingBlock:^(NSTrackingArea * _Nonnull trackingArea, NSUInteger idx, BOOL * _Nonnull stop) {
 		[self removeTrackingArea:trackingArea];
 	}];


### PR DESCRIPTION
From the documentation for `updateTrackingAreas` (emphasis mine):

"You should override this method to remove out of date tracking areas and add recomputed tracking areas; **your implementation should call super**."