### PR TITLE
Fix potential updateTrackingAreas bug with tooltips and cells

### DIFF
--- a/JNWCollectionView/JNWCollectionViewCell.m
+++ b/JNWCollectionView/JNWCollectionViewCell.m
@@ -123,6 +123,7 @@
 	[super updateTrackingAreas];
 	if (self.trackingArea) {
 		[self removeTrackingArea:self.trackingArea];
+		self.trackingArea = nil;
 	}
 
 	NSTrackingAreaOptions options = (NSTrackingActiveAlways | NSTrackingInVisibleRect | NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved);

--- a/JNWCollectionView/JNWCollectionViewCell.m
+++ b/JNWCollectionView/JNWCollectionViewCell.m
@@ -69,6 +69,7 @@
 
 @interface JNWCollectionViewCell()
 @property (nonatomic, strong) JNWCollectionViewCellBackgroundView *backgroundView;
+@property (nonatomic, strong) NSTrackingArea *trackingArea;
 @end
 
 @implementation JNWCollectionViewCell
@@ -120,13 +121,13 @@
 
 - (void)updateTrackingAreas {
 	[super updateTrackingAreas];
-	[[self.trackingAreas copy] enumerateObjectsUsingBlock:^(NSTrackingArea * _Nonnull trackingArea, NSUInteger idx, BOOL * _Nonnull stop) {
-		[self removeTrackingArea:trackingArea];
-	}];
+	if (self.trackingArea) {
+		[self removeTrackingArea:self.trackingArea];
+	}
 
 	NSTrackingAreaOptions options = (NSTrackingActiveAlways | NSTrackingInVisibleRect | NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved);
-	NSTrackingArea *area = [[NSTrackingArea alloc] initWithRect:[self bounds] options:options owner:self userInfo:nil];
-	[self addTrackingArea:area];
+	self.trackingArea = [[NSTrackingArea alloc] initWithRect:[self bounds] options:options owner:self userInfo:nil];
+	[self addTrackingArea:self.trackingArea];
 }
 
 - (NSView *)contentView {


### PR DESCRIPTION
In one of my personal projects, I found that removing all `NSTrackingArea` objects for a view could cause tooltips to stop working. This pull request reflects the fix for that -- don't remove all tracking areas! Even if the tooltip bug doesn't necessarily exist for `JNWCollectionViewCells`, this should speed up the `updateTrackingAreas` function slightly by removing the array copy.