### PR TITLE
fixed scroll layout in 10.12

### DIFF
--- a/JNWCollectionView/JNWCollectionViewFramework.m
+++ b/JNWCollectionView/JNWCollectionViewFramework.m
@@ -28,6 +28,10 @@
 #import "JNWCollectionViewLayout.h"
 #import "JNWCollectionViewLayout+Private.h"
 
+#ifndef NSAppKitVersionNumber10_11
+#define NSAppKitVersionNumber10_11 1404
+#endif
+
 typedef NS_ENUM(NSInteger, JNWCollectionViewSelectionType) {
 	JNWCollectionViewSelectionTypeSingle,
 	JNWCollectionViewSelectionTypeExtending,
@@ -637,6 +641,17 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 
 		[self performFullRelayoutForcingSubviewsReset:NO];
 	}
+}
+
+- (void)reflectScrolledClipView:(NSClipView*)clipView {
+    [super reflectScrolledClipView:clipView];
+    
+    // 10.12 started optimizing the layout pass and reducing the number of calls to layout(). As
+    // such, invalidate our layout when the scroll changes on 10.12 and above.
+    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_11) {
+        // Invalidate our layout when we our scrolled. This is required for 10.12 and above.
+        self.needsLayout = YES;
+    }
 }
 
 - (void)collectionViewLayoutWasInvalidated:(JNWCollectionViewLayout *)layout {


### PR DESCRIPTION
Right now, JNWCollectionView does not relayout when scrolled on 10.12 due to some OSX layout 'optimizations' ... 

See - https://developer.apple.com/library/prerelease/content/releasenotes/AppKit/RN-AppKit/#10_12Layout

> AppKit is now more efficient about only calling -layout on views when actually necessary, which can reveal holes where code previously did not properly invalidate layout when necessary (the above CoreAnimation case being one of those instances). If you find -layout method not being called when expected on your view, make sure that the view is actually marked as needsLayout=YES.
