### PR TITLE
Fix slow resize performance by changing rowEnd calculation by adding rowsInRect to rowBegin

### DIFF
--- a/JNWCollectionView/JNWCollectionViewGridLayout.m
+++ b/JNWCollectionView/JNWCollectionViewGridLayout.m
@@ -277,7 +277,8 @@ static const CGSize JNWCollectionViewGridLayoutDefaultSize = (CGSize){ 44.f, 44.
 	CGFloat relativeRectTop = MAX(0, CGRectGetMinY(rect) - section.offset);
 	CGFloat relativeRectBottom = CGRectGetMaxY(rect) - section.offset;
 	NSInteger rowBegin = relativeRectTop / (self.itemSize.height + self.verticalSpacing);
-	NSInteger rowEnd = floorf(relativeRectBottom / self.itemSize.height);
+       NSInteger rowsInRect = ceil(rect.size.height / (self.itemSize.height + self.verticalSpacing));
+       NSInteger rowEnd = floorf(rowBegin+rowsInRect);
 	return NSMakeRange(rowBegin, 1 + rowEnd - rowBegin);
 }
 


### PR DESCRIPTION
Hi,

I've found an issue where the window resize performance of the GridLayout is very poor when dealing with large collections.  This is most noticeable as the scroll offset gets higher.

I've traced the issue to an improper calculation for the rowEnd value inside `- (NSRange)rowsInRect:(CGRect)rect fromSection:(JNWCollectionViewGridLayoutSection *)section`

I've changed the calculation slightly and fixed the issue in this pull request.

Cheers,
Daniel