### PR TITLE
fix crash on firstTopLevelObjectOfClass

### DIFF
--- a/JNWCollectionView/JNWCollectionViewFramework.m
+++ b/JNWCollectionView/JNWCollectionViewFramework.m
@@ -252,7 +252,7 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 }
 
 - (id)firstTopLevelObjectOfClass:(Class)objectClass inNib:(NSNib *)nib {
-    NSArray *topLevelObjects = nil;
+	NSArray *topLevelObjects = nil;
 	return [self firstTopLevelObjectOfClass:objectClass inNib:nib topLevelObjects:&topLevelObjects];
 }
 

--- a/JNWCollectionView/JNWCollectionViewFramework.m
+++ b/JNWCollectionView/JNWCollectionViewFramework.m
@@ -252,7 +252,8 @@ static void JNWCollectionViewCommonInit(JNWCollectionView *collectionView) {
 }
 
 - (id)firstTopLevelObjectOfClass:(Class)objectClass inNib:(NSNib *)nib {
-	return [self firstTopLevelObjectOfClass:objectClass inNib:nib topLevelObjects:nil];
+    NSArray *topLevelObjects = nil;
+	return [self firstTopLevelObjectOfClass:objectClass inNib:nib topLevelObjects:&topLevelObjects];
 }
 
 - (id)firstTopLevelObjectOfClass:(Class)objectClass inNib:(NSNib *)nib topLevelObjects:(NSArray**)objects {


### PR DESCRIPTION
crash when called from dequeueReusableSupplementaryViewOfKind

line 262 expected a nonull NSArray** by referencing *objects